### PR TITLE
Rewrite all comments to use TomDoc

### DIFF
--- a/src/biscotto.coffee
+++ b/src/biscotto.coffee
@@ -9,43 +9,42 @@ Parser    = require './parser'
 Generator = require './generator'
 exec = require('child_process').exec
 
-# Biscotto - the TomDoc-CoffeeScript API documentation generator
-#
+# Public: Biscotto - the TomDoc-CoffeeScript API documentation generator
 module.exports = class Biscotto
 
-  # Get the current Biscotto version
+  # Public: Get the current Biscotto version
   #
-  # Returns a [String] representing the Biscotto version
-  #
+  # Returns a {String} representing the Biscotto version
   @version: ->
     'v' + JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'))['version']
 
-  # Run the documentation generator. This is usually done through
+  # Public: Run the documentation generator. This is usually done through
   # the command line utility `biscotto` that is provided by this package.
+  #
+  # This function sets up all of the configuration options used by Biscotto.
   #
   # You can also run the documentation generation without writing files
   # to the file system, by supplying a callback function.
   #
-  # done - The documentation done callback (a [Function])
-  # file - The new file callback (a [Function])
-  # analytics - The Google analytics tracking code (a [String])
-  # homepage - The homepage in the breadcrumbs (a [String])
+  # done - A {Function} to callback once the function is done
+  # file - A {Function} to callback on every file
+  # analytics - A {String} representing Google analytics tracking code
+  # homepage - The {String} homepage in the breadcrumbs
   #
   # Examples
   #
-  #   biscotto = require 'biscotto'
+  #    biscotto = require 'biscotto'
   #
-  #   file = (filename, content) ->
-  #     console.log "New file %s with content %s", filename, content
+  #    file = (filename, content) ->
+  #      console.log "New file %s with content %s", filename, content
   #
-  #   done = (err) ->
-  #     if err
-  #       console.log "Cannot generate documentation:", err
-  #     else
-  #       console.log "Documentation generated"
+  #    done = (err) ->
+  #      if err
+  #        console.log "Cannot generate documentation:", err
+  #      else
+  #        console.log "Documentation generated"
   #
-  #   biscotto.run file, done
-  #
+  #    biscotto.run file, done
   #
   @run: (done, file, analytics = false, homepage = false) ->
 
@@ -244,22 +243,19 @@ module.exports = class Biscotto
       console.log "Cannot generate documentation: #{ error.message }"
       throw error
 
-  # Get the Biscotto script content that is used in the webinterface
+  # Public: Get the Biscotto script content that is used in the webinterface
   #
-  # Returns the script content (a [String])
-  #
+  # Returns the script contents as a {String}.
   @script: ->
     @biscottoScript or= fs.readFileSync path.join(__dirname, '..', 'theme', 'default', 'assets', 'biscotto.js'), 'utf-8'
 
-  # Get the Biscotto style content that is used in the webinterface
+  # Public: Get the Biscotto style content that is used in the webinterface
   #
-  # Returns the style content (a [String])
-  #
+  # Returns the style content as a {String}.
   @style: ->
     @biscottoStyle or= fs.readFileSync path.join(__dirname, '..', 'theme', 'default', 'assets', 'biscotto.css'), 'utf-8'
 
-  # Find the source directories.
-  #
+  # Public: Find the source directories.
   @detectSources: (done) ->
     Async.filter [
       'src'
@@ -269,8 +265,7 @@ module.exports = class Biscotto
       results.push '.' if results.length is 0
       done null, results
 
-  # Find the project README.
-  #
+  # Public: Find the project's README.
   @detectReadme: (done) ->
     Async.filter [
       'README.markdown'
@@ -281,8 +276,7 @@ module.exports = class Biscotto
       'readme'
     ], (fs.exists || path.exists), (results) -> done null, _.first(results) || ''
 
-  # Find extra project files.
-  #
+  # Public: Find extra project files in the repository.
   @detectExtras: (done) ->
     Async.filter [
       'CHANGELOG.markdown'
@@ -297,10 +291,10 @@ module.exports = class Biscotto
       'LICENSE.GPL'
     ], (fs.exists || path.exists), (results) -> done null, results
 
-  # Find the project name by either parse `package.json`
-  # or get the current working directory name.
+  # Public: Find the project name by either parsing `package.json`,
+  # or getting the current working directory name.
   #
-  # done - The callback to call
+  # done - The {Function} callback to call once this is done
   @detectName: (done) ->
     if (fs.exists || path.exists)('package.json')
       name = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'))['name']
@@ -309,12 +303,18 @@ module.exports = class Biscotto
 
     done null, name.charAt(0).toUpperCase() + name.slice(1)
 
+  # Public: Find the project's latest Git tag.
+  #
+  # done - The {Function} callback to call once this is done
   @detectTag: (done) ->
     exec 'git describe --abbrev=0 --tags', (error, stdout, stderr) ->
       currentTag = stdout || "master"
 
       done null, currentTag
 
+  # Public: Find the project's Git remote.origin URL.
+  #
+  # done - The {Function} callback to call once this is done
   @detectOrigin: (done) ->
     exec 'git config --get remote.origin.url', (error, stdout, stderr) ->
       url = stdout
@@ -323,5 +323,5 @@ module.exports = class Biscotto
           url = url.replace(/\.git/, '')
         else if url.match /git@github.com/    # e.g., git@github.com:foo/bar.git
           url = url.replace(/^git@github.com:/, 'https://github.com/').replace(/\.git/, '')
-      
+
       done null, url

--- a/src/nodes/class.coffee
+++ b/src/nodes/class.coffee
@@ -6,17 +6,15 @@ Property      = require './property'
 Doc           = require './doc'
 _             = require 'underscore'
 
-# A CoffeeScript class
-#
+# Public: The Node representation of a CoffeeScript class.
 module.exports = class Class extends Node
 
-  # Construct a class
+  # Constructs a class.
   #
-  # node - the class node (a [Object])
-  # fileName - the filename (a [String])
-  # options - the parser options (a [Object])
-  # comment - the comment node (a [Object])
-  #
+  # node - The class node (a {Object})
+  # fileName - The filename (a {String})
+  # options - The parser options (a {Object})
+  # comment - The comment node (a {Object})
   constructor: (@node, @fileName, @lineMapping, @options, comment) ->
     try
       @methods = []
@@ -120,29 +118,25 @@ module.exports = class Class extends Node
     catch error
       console.warn('Create class error:', @node, error) if @options.verbose
 
-  # Get the source file name.
+  # Public: Get the source file name.
   #
-  # Returns the filename of the class (a [String])
-  #
+  # Returns the filename of the class (a {String})
   getFileName: -> @fileName
 
-  # Get the class doc
+  # Public: Get the class doc
   #
   # Returns the class doc (a [Doc])
-  #
   getDoc: -> @doc
 
-  # Alias for {#getClassName}
+  # Public: Alias for {.getClassName}
   #
-  # Returns the full class name (a [String])
-  #
+  # Returns the full class name (a {String})
   getFullName: ->
     @getClassName()
 
-  # Get the full class name
+  # Public: Get the full class name
   #
-  # Returns the class (a [String])
-  #
+  # Returns the class (a {String})
   getClassName: ->
     try
       unless @className || !@node.variable
@@ -169,10 +163,9 @@ module.exports = class Class extends Node
     catch error
       console.warn("Get class classname error at #{@fileName}:", @node, error) if @options.verbose
 
-  # Get the class name
+  # Public: Get the class name
   #
-  # Returns the name (a [String])
-  #
+  # Returns the name (a {String})
   getName: ->
     try
       unless @name
@@ -185,8 +178,7 @@ module.exports = class Class extends Node
 
   # Public: Get the source line number
   #
-  # Returns a {Number}
-  #
+  # Returns a {Number}.
   getLocation: ->
     try
       unless @location
@@ -201,10 +193,9 @@ module.exports = class Class extends Node
     catch error
       console.warn("Get location error at #{@fileName}:", @node, error) if @options.verbose
 
-  # Get the class namespace
+  # Public: Get the class namespace
   #
-  # Returns the namespace (a [String])
-  #
+  # Returns the namespace (a {String}).
   getNamespace: ->
     try
       unless @namespace
@@ -218,10 +209,9 @@ module.exports = class Class extends Node
     catch error
       console.warn("Get class namespace error at #{@fileName}:", @node, error) if @options.verbose
 
-  # Get the full parent class name
+  # Public: Get the full parent class name
   #
-  # Returns the parent class name (a [String])
-  #
+  # Returns the parent class name (a {String}).
   getParentClassName: ->
     try
       unless @parentClassName
@@ -249,12 +239,11 @@ module.exports = class Class extends Node
     catch error
       console.warn("Get class parent classname error at #{@fileName}:", @node, error) if @options.verbose
 
-  # Get all methods.
+  # Public: Get all methods.
   #
-  # Returns the methods
-  #
+  # Returns the methods as an {Array}.
   getMethods: ->
-    _.filter(@methods, (method) => 
+    _.filter(@methods, (method) =>
       if !@options.private && method.doc.status == "Private"
         return false
       else if !@options.internal && method.doc.status == "Internal"
@@ -263,16 +252,14 @@ module.exports = class Class extends Node
         return true
     )
 
-  # Get all variables.
+  # Public: Get all variables.
   #
-  # Returns the variables
-  #
+  # Returns the variables as an {Array}.
   getVariables: -> @variables
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
   # Returns the JSON object (an {Object})
-  #
   toJSON: ->
     json =
       file: @getFileName()

--- a/src/nodes/doc.coffee
+++ b/src/nodes/doc.coffee
@@ -6,16 +6,15 @@ marked = require 'marked'
 _      = require 'underscore'
 _.str  = require 'underscore.string'
 
-# A documentation node is responsible for parsing
+# Public: A documentation node is responsible for parsing
 # the comments for known tags.
 #
 module.exports = class Doc extends Node
 
-  # Construct a documentation
+  # Public: Construct a documentation node.
   #
-  # node - the comment node (a [Object])
-  # options - the parser options (a [Object])
-  #
+  # node - The comment node (a {Object})
+  # options - The parser options (a {Object})
   constructor: (@node, @options) ->
     try
       if @node
@@ -24,23 +23,22 @@ module.exports = class Doc extends Node
     catch error
       console.warn('Create doc error:', @node, error) if @options.verbose
 
-  # Determines if the current doc has some comments
+  # Public: Determines if the current doc has some comments
   #
-  # Returns the comment status (a [Boolean])
-  #
+  # Returns the comment status (a {Boolean}).
   hasComment: ->
     !_.str.isBlank(@comment)
 
-  # Is this doc public?
+  # Public: Is this doc public?
   #
   # Returns a {Boolean}.
   isPublic: ->
     /public/i.test(@status)
 
-  # Detect whitespace on the left and removes
+  # Public: Detect whitespace on the left and removes
   # the minimum whitespace ammount.
   #
-  # lines - The comment lines [[String]]
+  # lines - The comment lines [{String}]
   #
   # Examples
   #
@@ -49,8 +47,7 @@ module.exports = class Doc extends Node
   #
   # This will keep indention for examples intact.
   #
-  # Returns the left trimmed lines as an array of Strings
-  #
+  # Returns the left trimmed lines as an {Array} of {String}s.
   leftTrimBlock: (lines) ->
     # Detect minimal left trim amount
     trimMap = _.map lines, (line) ->
@@ -71,7 +68,7 @@ module.exports = class Doc extends Node
 
     lines
 
-  # Parse the given lines as TomDoc and adds the result
+  # Public: Parse the given lines as TomDoc and adds the result
   # to the result object.
   parseBlock: (lines) ->
     comment = []
@@ -115,9 +112,9 @@ module.exports = class Doc extends Node
     sentence = sentence[1].replace(/\s*#\s*$/, '') if sentence
     @summary = Markdown.convert(_.str.clean(sentence || text), true)
 
-  # Parse description.
+  # Public: Parse the member description.
   #
-  # section - String containing description.
+  # section - The section {String} containing a description.
   #
   # Returns nothing.
   parse_description: (section) ->
@@ -135,10 +132,10 @@ module.exports = class Doc extends Node
     else
       return { description: _.str.strip(section).replace(/\r?\n/g, ' ') }
 
-  # Parse examples.
+  # Public: Parse the member examples.
   #
-  # section  - String starting with `Examples`.
-  # sections - All sections subsequent to section.
+  # section  - The section {String} starting with "Examples"
+  # sections - All sections subsequent to `section`.
   #
   # Returns nothing.
   parse_examples: (section, sections) ->
@@ -153,9 +150,9 @@ module.exports = class Doc extends Node
 
     examples
 
-  # Parse returns section.
+  # Public: Parse the member's return values.
   #
-  # section - String containing Returns lines.
+  # section - The section {String} starting with "Returns"
   #
   # Returns nothing.
   parse_returns: (section) ->
@@ -177,10 +174,10 @@ module.exports = class Doc extends Node
 
     returns
 
-  # Parse arguments section. Arguments occur subsequent to
+  # Public: Parse the member's arguments. Arguments occur subsequent to
   # the description.
   #
-  # section - String containing agument definitions.
+  # section - A {String} containing the argument definitions.
   #
   # Returns nothing.
   parse_arguments: (section) ->
@@ -214,6 +211,11 @@ module.exports = class Doc extends Node
 
     args
 
+  # Internal: Deindents excess whitespace from the sections.
+  #
+  # lines - An {Array} of {String}s
+  #
+  # Returns `lines` with the leftmost whitespace removed.
   deindent: (lines) ->
     # remove indention
     spaces = _.map lines, (line) ->
@@ -231,10 +233,9 @@ module.exports = class Doc extends Node
       else
         line[space..-1]
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object.
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: ->
     if @node
       json =

--- a/src/nodes/file.coffee
+++ b/src/nodes/file.coffee
@@ -4,17 +4,17 @@ Method   = require './method'
 Variable = require './variable'
 Doc      = require './doc'
 
-# The file class is a `fake` class that wraps the
+# Public: The file class is a `fake` class that wraps the
 # file body to capture top-level assigned methods.
 #
 module.exports = class File extends Class
 
-  # Construct a File
+  # Public: Construct a `File` object.
   #
-  # node - the class node (a [Object])
-  # the - filename (a [String])
-  # options - the parser options (a [Object])
-  #
+  # node - The class node (a {Object})
+  # filename - A {String} representing the current filename
+  # lineMapping - An object mapping the actual position of a member to its Biscotto one
+  # options - Any additional parser options
   constructor: (@node, @fileName, @lineMapping, @options) ->
     try
       @methods = []
@@ -54,10 +54,9 @@ module.exports = class File extends Class
       console.warn('File class error:', @node, error) if @options.verbose
 
 
-  # Get the full file name with path
+  # Public: Get the full file name with path
   #
-  # Returns the file name with path (a [String])
-  #
+  # Returns the file name with path as a {String}.
   getFullName: ->
     fullName = @fileName
 
@@ -69,33 +68,29 @@ module.exports = class File extends Class
 
     fullName.replace(Path.sep, '/')
 
-  # Returns the file class name
+  # Public: Returns the file class name.
   #
-  # Returns the file name without path (a [String])
-  #
+  # Returns the file name without path as a {String}.
   getFileName: ->
     Path.basename @getFullName()
 
-  # Get the file path
+  # Public: Get the file path
   #
-  # Returns the file path (a [String])
-  #
+  # Returns the file path as a {String}.
   getPath: ->
     path = Path.dirname @getFullName()
     path = '' if path is '.'
     path
 
-  # Test if the file doesn't contain any top-level public methods.
+  # Public: Test if the file doesn't contain any top-level public methods.
   #
-  # Returns true if empty (a [Boolean])
-  #
+  # Returns `true` if empty.
   isEmpty: ->
     @getMethods().every (method) -> not /^public$/i.test(method.doc.status)
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: ->
     json =
       file: @getFileName()

--- a/src/nodes/method.coffee
+++ b/src/nodes/method.coffee
@@ -5,17 +5,17 @@ Doc       = require './doc'
 _         = require 'underscore'
 _.str     = require 'underscore.string'
 
-# A CoffeeScript method
-#
+# Public: The Node representation of a CoffeeScript method.
 module.exports = class Method extends Node
 
-  # Construct a method
+  # Public: Constructs the documentaion node.
   #
-  # @param [Class] entity the methods class
-  # @param [Object] node the node
-  # @param [Object] options the parser options
-  # @param [Object] comment the comment node
-  #
+  # entity - The method's {Class}
+  # node - The method node (a {Object})
+  # fileName - The filename (a {String})
+  # lineMapping - An object mapping the actual position of a member to its Biscotto one
+  # options - The parser options (a {Object})
+  # comment - The comment node (a {Object})
   constructor: (@entity, @node, @lineMapping, @options, comment) ->
     try
       @parameters = []
@@ -36,7 +36,7 @@ module.exports = class Method extends Node
 
   # Get the method type, either `class` or `instance`
   #
-  # @return [String] the method type
+  # @return {String} the method type
   #
   getType: ->
     unless @type
@@ -58,7 +58,7 @@ module.exports = class Method extends Node
 
   # Get the full method signature.
   #
-  # @return [String] the signature
+  # @return {String} the signature
   #
   getSignature: ->
     try
@@ -116,7 +116,7 @@ module.exports = class Method extends Node
 
   # Get the short method signature.
   #
-  # @return [String] the short signature
+  # @return {String} the short signature
   #
   getShortSignature: ->
     try
@@ -137,7 +137,7 @@ module.exports = class Method extends Node
 
   # Get the method name
   #
-  # @return [String] the method name
+  # @return {String} the method name
   #
   getName: ->
     try
@@ -198,7 +198,7 @@ module.exports = class Method extends Node
 
   # Get a JSON representation of the object
   #
-  # @return [Object] the JSON object
+  # @return {Object} the JSON object
   #
   toJSON: ->
     json =

--- a/src/nodes/mixin.coffee
+++ b/src/nodes/mixin.coffee
@@ -3,17 +3,16 @@ Method   = require './method'
 Variable = require './variable'
 Doc      = require './doc'
 
-# A CoffeeScript mixins
+# Public: The Node representation of a CoffeeScript mixins
 #
 module.exports = class Mixin extends Node
 
-  # Construct a mixin
+  # Public: Construct a mixin
   #
-  # node - the mixin node (a [Object])
-  # the - filename (a [String])
-  # options - the parser options (a [Object])
-  # comment - the comment node (a [Object])
-  #
+  # node - The mixin node (a {Object})
+  # fileName - The filename (a {String})
+  # options - The parser options (a {Object})
+  # comment - The comment node (a {Object})
   constructor: (@node, @fileName, @options, comment) ->
     try
       @methods = []
@@ -60,22 +59,19 @@ module.exports = class Mixin extends Node
     catch error
       console.warn('Create mixin error:', @node, error) if @options.verbose
 
-  # Get the source file name.
+  # Public: Get the source file name.
   #
-  # Returns the filename of the mixin (a [String])
-  #
+  # Returns the filename of the mixin (a {String}).
   getFileName: -> @fileName
 
-  # Get the mixin doc
+  # Public: Get the mixin doc
   #
   # Returns the mixin doc (a [Doc])
-  #
   getDoc: -> @doc
 
-  # Get the full mixin name
+  # Public: Get the full mixin name
   #
-  # Returns full mixin name (a [String])
-  #
+  # Returns full mixin name (a {String}).
   getMixinName: ->
     try
       unless @mixinName
@@ -89,15 +85,13 @@ module.exports = class Mixin extends Node
     catch error
       console.warn('Get mixin full name error:', @node, error) if @options.verbose
 
-  # Alias for {Mixin#getMixinName}
-  #
+  # Public: Alias for {.getMixinName}
   getFullName: ->
     @getMixinName()
 
-  # Get the mixin name
+  # Public: Gets the mixin name
   #
-  # Returns the name (a [String])
-  #
+  # Returns the name (a {String}).
   getName: ->
     try
       unless @name
@@ -108,10 +102,9 @@ module.exports = class Mixin extends Node
     catch error
       console.warn('Get mixin name error:', @node, error) if @options.verbose
 
-  # Get the mixin namespace
+  # Public: Get the mixin namespace
   #
-  # Returns the namespace (a [String])
-  #
+  # Returns the namespace (a {String}).
   getNamespace: ->
     try
       unless @namespace
@@ -125,22 +118,19 @@ module.exports = class Mixin extends Node
     catch error
       console.warn('Get mixin namespace error:', @node, error) if @options.verbose
 
-  # Get all methods.
+  # Public: Get all methods.
   #
-  # Returns  (a ) [Array<Method>] the methods
-  #
+  # Returns an {Array} of all the {Method}s.
   getMethods: -> @methods
 
   # Get all variables.
   #
-  # Returns  (a ) [Array<Variable>] the variables
-  #
+  # Returns an {Array} of all the {Variable}s.
   getVariables: -> @variables
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: ->
     json =
       file: @getFileName()

--- a/src/nodes/node.coffee
+++ b/src/nodes/node.coffee
@@ -1,12 +1,11 @@
-# Base class for all nodes.
+# Public: The base class for all nodes.
 #
 module.exports = class Node
 
-  # Find an ancestor node by type.
+  # Public: Find an ancestor node by type.
   #
-  # type - the class name (a [String])
-  # node - the CoffeeScript node (a [Base])
-  #
+  # type - The type name (a {String})
+  # node - The CoffeeScript node to search on (a {Base})
   findAncestor: (type, node = @node) ->
     if node.ancestor
       if node.ancestor.constructor.name is type

--- a/src/nodes/parameter.coffee
+++ b/src/nodes/parameter.coffee
@@ -3,21 +3,19 @@ Node      = require './node'
 _         = require 'underscore'
 _.str     = require 'underscore.string'
 
-# A CoffeeScript method parameter
-#
+# Public: The Node representation of a CoffeeScript method parameter.
 module.exports = class Parameter extends Node
 
-  # Construct a parameter
+  # Public: Construct a parameter node.
   #
-  # node - the node (a [Object])
-  # options - the parser options (a [Object])
-  #
+  # node - The node (a {Object})
+  # options - The parser options (a {Object})
+  # optionized - A {Boolean} indicating if the parameter is a set of options
   constructor: (@node, @options, @optionized) ->
 
-  # Get the full parameter signature.
+  # Public: Get the full parameter signature.
   #
-  # Returns the signature (a [String])
-  #
+  # Returns the signature (a {String}).
   getSignature: ->
     try
       unless @signature
@@ -34,10 +32,9 @@ module.exports = class Parameter extends Node
     catch error
       console.warn('Get parameter signature error:', @node, error) if @options.verbose
 
-  # Get the parameter name
+  # Public: Get the parameter name
   #
-  # Returns the name (a [String])
-  #
+  # Returns the name (a {String}).
   getName: (i = -1) ->
     try
       # params like `method: ({option1, option2}) ->`
@@ -59,10 +56,9 @@ module.exports = class Parameter extends Node
     catch error
       console.warn('Get parameter name error:', @node, error) if @options.verbose
 
-  # Get the parameter default value
+  # Public: Get the parameter default value
   #
-  # Returns the default (a [String])
-  #
+  # Returns the default (a {String}).
   getDefault: (i = -1) ->
     try
       # for optionized arguments
@@ -77,6 +73,9 @@ module.exports = class Parameter extends Node
       else
         console.warn('Get parameter default error:', @node, error) if @options.verbose
 
+  # Public: Gets the defaults of the optionized parameters.
+  #
+  # Returns the defaults as a {String}.
   getOptionizedDefaults: ->
     return '' unless @node.value?
 
@@ -86,10 +85,9 @@ module.exports = class Parameter extends Node
 
     return "{" + defaults.join(",") + "}"
 
-  # Tests if the parameters is a splat
+  # Public: Checks if the parameters is a splat
   #
-  # Returns true if a splat (a [Boolean])
-  #
+  # Returns `true` if a splat (a {Boolean}).
   isSplat: ->
     try
       @node.splat is true
@@ -97,10 +95,9 @@ module.exports = class Parameter extends Node
     catch error
       console.warn('Get parameter splat type error:', @node, error) if @options.verbose
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: (i = -1) ->
     json =
       name: @getName(i)

--- a/src/nodes/property.coffee
+++ b/src/nodes/property.coffee
@@ -4,7 +4,7 @@ Doc       = require './doc'
 _         = require 'underscore'
 _.str     = require 'underscore.string'
 
-# A class property that is defined by custom property set/get methods.
+# Public: A class property that is defined by custom property set/get methods.
 #
 # Examples
 #
@@ -18,14 +18,14 @@ _.str     = require 'underscore.string'
 #
 module.exports = class Property extends Node
 
-  # Construct a new property
+  # Public: Construct a new property node.
   #
-  # entity - The methods class (a [Class])
-  # node - The class node (a [Object])
-  # options - The parser options (a [Object])
-  # name - The name of the property (a [String])
-  # comment - The comment node (a [Object])
-  #
+  # entity - The property's {Class}
+  # node - The property node (a {Object})
+  # lineMapping - An object mapping the actual position of a member to its Biscotto one
+  # options - The parser options (a {Object})
+  # name - The filename (a {String})
+  # comment - The comment node (a {Object})
   constructor: (@entity, @node, @lineMapping, @options, @name, comment) ->
     @doc = new Doc(comment, @options)
 
@@ -34,8 +34,7 @@ module.exports = class Property extends Node
 
   # Public: Get the source line number
   #
-  # Returns a {Number}
-  #
+  # Returns a {Number}.
   getLocation: ->
     try
       unless @location
@@ -48,10 +47,9 @@ module.exports = class Property extends Node
     catch error
       console.warn("Get location error at #{@fileName}:", @node, error) if @options.verbose
 
-  # Get the property signature.
+  # Public: Get the property signature.
   #
-  # Returns the signature (a [String])
-  #
+  # Returns the signature (a {String})
   getSignature: ->
     try
       unless @signature
@@ -67,10 +65,9 @@ module.exports = class Property extends Node
     catch error
       console.warn('Get property signature error:', @node, error) if @options.verbose
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object})
   toJSON: ->
     {
       name: @name

--- a/src/nodes/variable.coffee
+++ b/src/nodes/variable.coffee
@@ -1,18 +1,17 @@
 Node      = require './node'
 Doc      = require './doc'
 
-# A CoffeeScript variable
-#
+# Public: The Node representation of a CoffeeScript variable.
 module.exports = class Variable extends Node
 
-  # Construct a variable
+  # Public: Construct a variable node.
   #
-  # entity - the variables class (a [Class])
-  # node - the node (a [Object])
-  # options - the parser options (a [Object])
-  # classType - whether its a class variable or not (a [Boolean])
-  # comment - the comment node (a [Object])
-  #
+  # entity - The variable's {Class}
+  # node - The variable node (a {Object})
+  # smc - An object mapping the actual position of a member to its Biscotto one
+  # options - The parser options (a {Object})
+  # classType - A {Boolean} indicating if the class is a `class` or an `instance`
+  # comment - The comment node (a {Object})
   constructor: (@entity, @node, @smc, @options, @classType = false, comment = null) ->
     try
       @doc = new Doc(comment, @options)
@@ -21,19 +20,18 @@ module.exports = class Variable extends Node
     catch error
       console.warn('Create variable error:', @node, error) if @options.verbose
 
-  # Get the variable type, either `class` or `constant`
+  # Public: Get the variable type, either `class` or `constant`
   #
-  # Returns the variable type (a [String])
-  #
+  # Returns the variable type (a {String}).
   getType: ->
     unless @type
       @type = if @classType then 'class' else 'instance'
 
     @type
 
-  # Test if the given value should be treated ad constant.
+  # Public: Test if the given value should be treated ad constant.
   #
-  # Returns true if a constant (a [Boolean])
+  # Returns true if a constant (a {Boolean})
   #
   isConstant: ->
     unless @constant
@@ -41,16 +39,14 @@ module.exports = class Variable extends Node
 
     @constant
 
-  # Get the class doc
+  # Public: Get the class doc
   #
-  # Returns the class doc (a [Doc])
-  #
+  # Returns the class doc (a [Doc]).
   getDoc: -> @doc
 
-  # Get the variable name
+  # Public: Get the variable name
   #
-  # Returns the variable name (a [String])
-  #
+  # Returns the variable name (a {String}).
   getName: ->
     try
       unless @name
@@ -71,8 +67,7 @@ module.exports = class Variable extends Node
 
   # Public: Get the source line number
   #
-  # Returns a {Number}
-  #
+  # Returns a {Number}.
   getLocation: ->
     try
       unless @location
@@ -84,11 +79,10 @@ module.exports = class Variable extends Node
 
     catch error
       console.warn("Get location error at #{@fileName}:", @node, error) if @options.verbose
-      
-  # Get the variable value.
+
+  # Public: Get the variable value.
   #
-  # Returns the value (a [String])
-  #
+  # Returns the value (a {String}).
   getValue: ->
     try
       unless @value
@@ -99,10 +93,9 @@ module.exports = class Variable extends Node
     catch error
       console.warn('Get method value error:', @node, error) if @options.verbose
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: ->
     json =
       doc: @doc

--- a/src/nodes/virtual_method.coffee
+++ b/src/nodes/virtual_method.coffee
@@ -5,22 +5,20 @@ Doc       = require './doc'
 _         = require 'underscore'
 _.str     = require 'underscore.string'
 
-# A virtual method that has been declared by the `@method` tag.
-#
+# Public: The Node representation of a CoffeeScript  virtual method that has
+# been declared by the `@method` tag.
 module.exports = class VirtualMethod extends Node
 
-  # Construct a virtual method
+  # Public: Construct a virtual method node.
   #
-  # entity - the methods class (a [Class])
-  # doc - the virtual doc (a [Doc])
-  # options - the parser options (a [Object])
-  #
+  # entity - The method's {Class}
+  # doc - The property node (a {Object})
+  # options - The parser options (a {Object})
   constructor: (@entity, @doc, @options) ->
 
-  # Get the method type, either `class`, `instance` or `mixin`.
+  # Public: Get the method type, either `class`, `instance` or `mixin`.
   #
-  # Returns the method type (a [String])
-  #
+  # Returns the method type (a {String}).
   getType: ->
     unless @type
       if @doc.signature.substring(0, 1) is '.'
@@ -32,16 +30,14 @@ module.exports = class VirtualMethod extends Node
 
     @type
 
-  # Get the class doc
+  # Public: Get the class doc
   #
-  # Returns the class doc (a [Doc])
-  #
+  # Returns the class doc (a {Doc}).
   getDoc: -> @doc
 
-  # Get the full method signature.
+  # Public: Get the full method signature.
   #
-  # Returns the signature (a [String])
-  #
+  # Returns the signature (a {String}).
   getSignature: ->
     try
       unless @signature
@@ -72,10 +68,9 @@ module.exports = class VirtualMethod extends Node
     catch error
       console.warn('Get method signature error:', @node, error) if @options.verbose
 
-  # Get the short method signature.
+  # Public: Get the short method signature.
   #
-  # Returns the short signature (a [String])
-  #
+  # Returns the short signature (a {String}).
   getShortSignature: ->
     try
       unless @shortSignature
@@ -93,10 +88,9 @@ module.exports = class VirtualMethod extends Node
     catch error
       console.warn('Get method short signature error:', @node, error) if @options.verbose
 
-  # Get the method name
+  # Public: Get the method name
   #
-  # Returns the method name (a [String])
-  #
+  # Returns the method name (a {String}).
   getName: ->
     try
       unless @name
@@ -110,28 +104,24 @@ module.exports = class VirtualMethod extends Node
     catch error
       console.warn('Get method name error:', @node, error) if @options.verbose
 
-  # Get the method parameters
+  # Public: Get the method parameters
   #
   # params - The method parameters
-  #
   getParameters: -> @doc.params or []
 
-  # Get the method source in CoffeeScript
+  # Public: Get the method source in CoffeeScript
   #
-  # Returns the CoffeeScript source (a [String])
-  #
+  # Returns the CoffeeScript source (a {String}).
   getCoffeeScriptSource: ->
 
-  # Get the method source in JavaScript
+  # Public: Get the method source in JavaScript
   #
-  # Returns the JavaScript source (a [String])
-  #
+  # Returns the JavaScript source (a {String}).
   getJavaScriptSource: ->
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON object (a {Object}).
   toJSON: ->
     json =
       doc: @doc
@@ -140,8 +130,5 @@ module.exports = class VirtualMethod extends Node
       name: @getName()
       bound: false
       parameters: []
-
-    #for parameter in @getParameters()
-    #  json.parameters.push parameter.toJSON()
 
     json

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -12,15 +12,14 @@ VirtualMethod = require './nodes/virtual_method'
 {whitespace} = require('./util/text')
 {SourceMapConsumer} = require 'source-map'
 
-# CoffeeScript parser to convert the files into a
-# documentation domain nodes.
+# Public: This parser is responsible for converting each file into the intermediate /
+# AST representation as a JSON node.
 #
 module.exports = class Parser
 
-  # Construct the parser
+  # Public: Construct the parser
   #
-  # options - the parser options (a [Object])
-  #
+  # options - An {Object} of options
   constructor: (@options) ->
     @files   = []
     @classes = []
@@ -33,18 +32,17 @@ module.exports = class Parser
 
                         """
 
-  # Parse the given CoffeeScript file
+  # Public: Parse the given CoffeeScript file.
   #
-  # file - the CoffeeScript file name (a [String])
-  #
+  # file - A {String} representing the the CoffeeScript filename
   parseFile: (file) ->
     @parseContent fs.readFileSync(file, 'utf8'), file
     @fileCount += 1
 
-  # Parse the given CoffeeScript content
+  # Public: Parse the given CoffeeScript content.
   #
-  # content - the CoffeeScript file content (a [String])
-  # file - the CoffeeScript file name (a [String])
+  # content - A {String} representing the CoffeeScript file content
+  # file - A {String} representing the CoffeeScript file name
   #
   parseContent: (content, file = '') ->
     @previousNodes = []
@@ -115,10 +113,10 @@ module.exports = class Parser
 
     root
 
-  # Convert the comments to block comments, so they appear in the nodes.
+  # Public: Converts the comments to block comments, so they appear in the node structure.
+  # Only block comments are considered by Biscotto.
   #
-  # content - the CoffeeScript file content (a [String])
-  #
+  # content - A {String} representing the CoffeeScript file content
   convertComments: (content) ->
     result         = []
     comment        = []
@@ -221,22 +219,21 @@ module.exports = class Parser
 
     [result.join('\n'), lineMapping]
 
-  # Attach each parent to its children, so we are able
+  # Public: Attach each parent to its children, so we are able
   # to traverse the ancestor parse tree. Since the
   # parent attribute is already used in the class node,
   # the parent is stored as `ancestor`.
   #
-  # nodes - the CoffeeScript nodes (a [Base])
+  # nodes - A {Base} representing the CoffeeScript nodes
   #
   linkAncestors: (node) ->
     node.eachChild (child) =>
       child.ancestor = node
       @linkAncestors child
 
-  # Get all parsed methods
+  # Public: Get all the parsed methods.
   #
-  # Returns  (a ) [Array<Method>] all methods
-  #
+  # Returns an {Array} of {Method}s.
   getAllMethods: ->
     unless @methods
       @methods = []
@@ -252,10 +249,9 @@ module.exports = class Parser
 
     @methods
 
-  # Get all parsed variables
+  # Public: Get all parsed variables.
   #
-  # Returns  (a ) [Array<Variable>] all variables
-  #
+  # Returns an {Array} of {Variable}s.
   getAllVariables: ->
     unless @variables
       @variables = []
@@ -271,8 +267,7 @@ module.exports = class Parser
 
     @variables
 
-  # Show the parsing statistics
-  #
+  # Public: Show the final parsing statistics.
   showResult: (generator) ->
     fileCount      = @files.length
 
@@ -337,10 +332,9 @@ module.exports = class Parser
     if @options.json && @options.json.length
       fs.writeFileSync @options.json, JSON.stringify(@toJSON(), null, "    ");
 
-  # Get a JSON representation of the object
+  # Public: Get a JSON representation of the object.
   #
-  # Returns the JSON object (a [Object])
-  #
+  # Returns the JSON {Object}.
   toJSON: ->
     json = []
 

--- a/src/util/markdown.coffee
+++ b/src/util/markdown.coffee
@@ -1,10 +1,7 @@
 marked = require 'marked'
 
-# It looks like all the markdown libraries for node doesn't get
-# GitHub flavored markdown right. This helper class post-processes
-# the best available output from the marked library to conform to
-# GHM. In addition the allowed tags can be limited.
-#
+# Internal: A class to post-process the best available output from the marked
+# library to conform to GHM. In addition the allowed tags can be limited.
 module.exports = class Markdown
 
   # Tags to keep when parsing is limited
@@ -14,8 +11,8 @@ module.exports = class Markdown
   # is true, then all unwanted elements are stripped from the
   # result and also all existing newlines.
   #
-  # markdown - the markdown markup (a [String])
-  # limit - if elements should be limited (a [Boolean])
+  # markdown - the markdown markup (a {String})
+  # limit - if elements should be limited (a {Boolean})
   #
   @convert: (markdown, limit = false, allowed = Markdown.limitedTags) ->
     return if markdown is undefined
@@ -33,9 +30,9 @@ module.exports = class Markdown
 
   # Strips all unwanted tag from the html
   #
-  # html - the Html to clean (a [String])
-  # allowed - the comma separated list of allowed tags (a [String])
-  # Returns the cleaned Html (a [String])
+  # html - the Html to clean (a {String})
+  # allowed - the comma separated list of allowed tags (a {String})
+  # Returns the cleaned Html (a {String})
   #
   @limit: (html, allowed) ->
     allowed = allowed.split ','

--- a/src/util/referencer.coffee
+++ b/src/util/referencer.coffee
@@ -2,36 +2,33 @@ _ = require 'underscore'
 path = require 'path'
 fs = require 'fs'
 
-# Class reference resolver.
+# Public: Responsible for resolving class references.
 #
 module.exports = class Referencer
 
-  # Construct a referencer.
+  # Public: Construct a referencer.
   #
   # classes - All known classes
   # mixins - All known mixins
-  # options - the parser options (a [Object])
-  #
+  # options - the parser options (a {Object})
   constructor: (@classes, @mixins, @options) ->
     @readStandardJSON()
     @resolveParamReferences()
     @errors = 0
 
-  # Get all direct subclasses.
+  # Public: Get all direct subclasses.
   #
-  # clazz - the parent class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the classes
-  #
+  # Returns an {Array} of {Class}es.
   getDirectSubClasses: (clazz) ->
     _.filter @classes, (cl) -> cl.getParentClassName() is clazz.getFullName()
 
-  # Get all inherited methods.
+  # Public: Get all inherited methods.
   #
-  # clazz - the parent class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the classes
-  #
+  # Returns the inherited methods.
   getInheritedMethods: (clazz) ->
     unless _.isEmpty clazz.getParentClassName()
       parentClass = _.find @classes, (c) -> c.getFullName() is clazz.getParentClassName()
@@ -40,12 +37,11 @@ module.exports = class Referencer
     else
       []
 
-  # Get all included mixins in the class hierarchy.
+  # Public: Get all included mixins in the class hierarchy.
   #
-  # clazz - the class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the mixins (a [Object])
-  #
+  # Returns an {Array} of {Mixin}s.
   getIncludedMethods: (clazz) ->
     result = {}
 
@@ -60,12 +56,11 @@ module.exports = class Referencer
 
     result
 
-  # Get all extended mixins in the class hierarchy.
+  # Public: Get all extended mixins in the class hierarchy.
   #
-  # clazz - the class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the mixins (a [Object])
-  #
+  # Returns an {Array} of {Mixin}s.
   getExtendedMethods: (clazz) ->
     result = {}
 
@@ -80,12 +75,11 @@ module.exports = class Referencer
 
     result
 
-  # Get all concerns
+  # Public: Get all concerns methods.
   #
-  # clazz - the class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the concerns (a [Object])
-  #
+  # Returns an {Array} of concern {Method}s.
   getConcernMethods: (clazz) ->
     result = {}
 
@@ -100,12 +94,11 @@ module.exports = class Referencer
 
     result
 
-  # Get a list of all methods from the given mixin name
+  # Public: Get a list of all methods from the given mixin name
   #
-  # name - The full name of the mixin
+  # name - The full name of the {Mixin}
   #
-  # Returns the mixin methods
-  #
+  # Returns the mixin methods as an {Array}.
   resolveMixinMethods: (name) ->
     mixin = _.find @mixins, (m) -> m.getMixinName() is name
 
@@ -116,12 +109,11 @@ module.exports = class Referencer
       @errors++
       []
 
-  # Get all inherited variables.
+  # Public: Get all inherited variables.
   #
-  # clazz - the parent class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the variables
-  #
+  # Returns an {Array} of {Variable}s.
   getInheritedVariables: (clazz) ->
     unless _.isEmpty clazz.getParentClassName()
       parentClass = _.find @classes, (c) -> c.getFullName() is clazz.getParentClassName()
@@ -130,21 +122,19 @@ module.exports = class Referencer
     else
       []
 
-  # Get all inherited constants.
+  # Public: Get all inherited constants.
   #
-  # clazz - the parent class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the constants
-  #
+  # Returns an {Array} of {Variable}s that are constants.
   getInheritedConstants: (clazz) ->
     _.filter @getInheritedVariables(clazz), (v) -> v.isConstant()
 
-  # Get all inherited properties.
+  # Public: Get all inherited properties.
   #
-  # clazz - the parent class (a [Class])
+  # clazz - The parent class (a {Class})
   #
-  # Returns the properties
-  #
+  # Returns an {Array} of {Property} types.
   getInheritedProperties: (clazz) ->
     unless _.isEmpty clazz.getParentClassName()
       parentClass = _.find @classes, (c) -> c.getFullName() is clazz.getParentClassName()
@@ -153,15 +143,14 @@ module.exports = class Referencer
     else
       []
 
-  # Create browsable links for known entities.
+  # Public: Creates browsable links for known entities.
   #
-  # See {#getLink}.
+  # See {.getLink}.
   #
-  # text - the text to parse. (a [String])
-  # path - the path prefix (a [String])
+  # text - The text to parse (a {String})
+  # path - The path prefix (a {String})
   #
-  # Returns the processed text (a [String])
-  #
+  # Returns the processed text (a {String})
   linkTypes: (text = '', path) ->
     text = text.split ','
 
@@ -170,15 +159,14 @@ module.exports = class Referencer
 
     text.join(', ')
 
-  # Create browsable links to a known entity.
+  # Public: Create browsable links to a known entity.
   #
-  # See {#getLink}.
+  # See {.getLink}.
   #
-  # text - the text to parse. (a {String})
-  # path - the path prefix (a {Number string string string.})
+  # text - The text to parse (a {String})
+  # path - The path prefix (a {String})
   #
-  # Returns the processed text (a [String])
-  #
+  # Returns the processed text (a {String})
   linkType: (text = '', path) ->
     text = _.str.escapeHTML text
 
@@ -188,29 +176,27 @@ module.exports = class Referencer
 
     text
 
-  # Get the link to classname.
+  # Public: Get the link to classname.
   #
-  # See {#linkTypes}.
+  # See {.linkTypes}.
   #
-  # classname - the class name (a [String])
-  # path - the path prefix (a [String])
+  # classname - The class name (a {String})
+  # path - The path prefix (a {String})
   #
   # Returns the link (if any)
-  #
   getLink: (classname, path) ->
     for clazz in @classes
       if classname is clazz.getFullName() then return "#{ path }classes/#{ clazz.getFullName().replace(/\./g, '/') }.html"
 
     undefined
 
-  # Resolve all tags on class and method json output.
+  # Public: Resolve all tags on class and method json output.
   #
-  # data - the json data (a [Object])
-  # entity - the entity context (a [Class])
-  # path - the path to the asset root (a [String])
+  # data - The JSON data (a {Object})
+  # entity - The entity context (a {Class})
+  # path - The path to the asset root (a {String})
   #
-  # Returns the json data with resolved references (a [Object])
-  #
+  # Returns the JSON data with resolved references (a {Object})
   resolveDoc: (data, entity, path) ->
     if data.doc
       if data.doc.see
@@ -257,7 +243,7 @@ module.exports = class Referencer
 
     data
 
-  # Search a text to find see links wrapped in curly braces.
+  # Public: Search a text to find see links wrapped in curly braces.
   #
   # Examples
   #
@@ -266,7 +252,6 @@ module.exports = class Referencer
   # text - The text to search (a {String})
   #
   # Returns the text with hyperlinks (a {String})
-  #
   resolveTextReferences: (text = '', entity, path) ->
     # Make curly braces within code blocks undetectable
     text = text.replace /<code(\s+[^>]*)?>(.|\n)+?<\/code>/mg, (match) -> match.replace(/{/mg, "\u0091").replace(/}/mg, "\u0092")
@@ -291,12 +276,10 @@ module.exports = class Referencer
     # Restore curly braces within code blocks
     text = text.replace /<code(\s+[^>]*)?>(.|\n)+?<\/code>/mg, (match) -> match.replace(/\u0091/mg, '{').replace(/\u0092/mg, '}')
 
-  # Resolves delegations; that is, methods whose source content come from
+  # Public: Resolves delegations; that is, methods whose source content come from
   # another file.
   #
-  # Conrefs, basically.
-  #
-  #
+  # These are basically conrefs.
   resolveDelegation: (origin, ref, entity) ->
 
     # Link to direct class methods
@@ -391,14 +374,13 @@ module.exports = class Referencer
 
     return [ origin.doc, origin.parameters ]
 
-  # Resolves curly-bracket reference links.
+  # Public: Resolves curly-bracket reference links.
   #
-  # see - the reference object (a [Object])
-  # entity - the entity context (a [Class])
-  # path - the path to the asset root (a [String])
+  # see - The reference object (a {Object})
+  # entity - The entity context (a {Class})
+  # path - The path to the asset root (a {String})
   #
-  # Returns the resolved see (a [Object])
-  #
+  # Returns the resolved see (a {Object}).
   resolveSee: (see, entity, path) ->
     # If a reference starts with a space like `{ a: 1 }`, then it's not a valid reference
     return see if see.reference.substring(0, 1) is ' '
@@ -503,16 +485,21 @@ module.exports = class Referencer
     else
       return ""
 
+  # Public: Constructs the documentation links for the standard JS objects.
+  #
+  # Returns a JSON {Object}.
   readStandardJSON: ->
     @standardObjs = JSON.parse(fs.readFileSync(path.join(__dirname, 'standardObjs.json'), 'utf-8'))
 
+  # Public: Checks to make sure that an object that's referenced exists in *standardObjs.json*.
+  #
+  # Returns a {Boolean}.
   verifyExternalObjReference: (name) ->
     @standardObjs[name] != undefined
 
-  # Resolve parameter references. This goes through all
+  # Public: Resolve parameter references. This goes through all
   # method parameter and see if a param doc references another
   # method. If so, copy over the doc meta data.
-  #
   resolveParamReferences: ->
     entities = _.union @classes, @mixins
 

--- a/src/util/standardObjs.json
+++ b/src/util/standardObjs.json
@@ -17,5 +17,6 @@
 	"Number" : "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Number",
 	"Object" : "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object",
 	"RegExp" : "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/RegExp",
-	"String" : "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String"
+	"String" : "https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String",
+	"Base": "http://coffeescript.org/documentation/docs/nodes.html#section-7"
 }

--- a/src/util/templater.coffee
+++ b/src/util/templater.coffee
@@ -6,17 +6,16 @@ _.str   = require 'underscore.string'
 walkdir = require 'walkdir'
 hamlc   = require 'haml-coffee'
 
-# Haml Coffee template compiler.
+# Public: Haml Coffee template compiler.
 #
 module.exports = class Templater
 
-  # Construct the templater. Reads all templates and constructs
+  # Public: Construct the templater. Reads all templates and constructs
   # the global template context.
   #
-  # options - the options (a [Object])
-  # referencer - the link type referencer (a [Referencer])
-  # parser - the biscotto parser (a [Parser])
-  #
+  # options - The options (a {Object})
+  # referencer - The link type referencer (a {Referencer})
+  # parser - The biscotto parser (a {Parser})
   constructor: (@options, @referencer, @parser) ->
     @JST = []
 
@@ -40,20 +39,18 @@ module.exports = class Templater
       if match = /theme[/\\]default[/\\]templates[/\\](.+).hamlc$/.exec filename
         @JST[match[1]] = hamlc.compile(fs.readFileSync(filename, 'utf-8'))
 
-  # Redirect template generation to a callback.
+  # Public: Redirect template generation to a callback.
   #
-  # file - the file callback function (a [Function])
-  #
+  # file - The file callback {Function}
   redirect: (file) -> @file = file
 
-  # Render the given template with the context and the
+  # Public: Render the given template with the context and the
   # global context object merged as template data. Writes
   # the file as the output filename.
   #
-  # template - the template name (a [String])
-  # context - the context object (a [Object])
-  # filename - the output file name (a [String])
-  #
+  # template - The template name (a {String})
+  # context - The context object (a {Object})
+  # filename - The output file name (a {String})
   render: (template, context = {}, filename = '') ->
     html = @JST[template](_.extend(@globalContext, context))
 

--- a/src/util/text.coffee
+++ b/src/util/text.coffee
@@ -1,13 +1,12 @@
-# Global text helpers
+# Public: Global text helpers.
 #
 module.exports =
 
-  # Whitespace helper function
+  # Public: Whitespace helper function
   #
-  # n - the number of spaces (a [Number])
+  # n - The number of spaces to create (a {Number})
   #
-  # Returns the space string (a [String])
-  #
+  # Returns the space string (a {String}).
   whitespace: (n) ->
     a = []
     while a.length < n


### PR DESCRIPTION
Because Biscotto was forked from [codo](https://github.com/coffeedoc/codo), all of the comments of the project itself were written in JSDoc.

This PR rewrites all the comments in Biscotto to use TomDoc notation. The docs can be generated with `bin/biscotto src/ --internal`. In a subsequent PR I'll create a workflow for updating Biscotto's gh-pages branch to host the docs for this tool.
