### PR TITLE
remove global coffee-script dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ the tests for Biscotto.
 
 ## Generate
 
-After the installation, you will have a `biscotto` binary that can be used to generate the documentation recursively for all CoffeeScript files within a directory. Note: The `coffee-script` module must be installed globally.
+After the installation, you will have a `biscotto` binary that can be used to generate the documentation recursively for all CoffeeScript files within a directory.
 
 To view a list of commands, type
 

--- a/bin/biscotto
+++ b/bin/biscotto
@@ -1,2 +1,3 @@
-#!/usr/bin/env coffee
-require('./../src/biscotto').run()
+#!/usr/bin/env node
+require('coffee-script/register');
+require('../src/biscotto').run();


### PR DESCRIPTION
Instead, this uses the `coffee-script/register` module already inside `/node_modules`.
