### PR TITLE
:bug: Fix returns failing to parse namespaced link

### DIFF
--- a/src/util/referencer.coffee
+++ b/src/util/referencer.coffee
@@ -485,7 +485,7 @@ module.exports = class Referencer
     see
 
   @getLinkMatch: (text) ->
-    if m = text.match(/\{(\w+)\}/)
+    if m = text.match(/\{([\w.]+)\}/)
       return m[1]
     else
       return ""


### PR DESCRIPTION
Given the following comment block: 

``` coffeescript
# Public: Some method comment
#
# Returns a {path.to.Class}.
method: -> 
```

The referencer failed to detect the link in the returns section due to its regexp matching only word characters and ignoring dots.
