### PR TITLE
Fix bugs on "Private/Internal/Deprecated" badges

### DIFF
--- a/src/nodes/doc.coffee
+++ b/src/nodes/doc.coffee
@@ -49,6 +49,12 @@ module.exports = class Doc extends Node
   isPrivate: ->
     not @isPublic() and not @isInternal()
 
+  isDeprecated: ->
+    /deprecated/i.test(@status)
+
+  isAbstract: ->
+    /abstract/i.test(@status)
+
   # Public: Detect whitespace on the left and removes
   # the minimum whitespace amount.
   #
@@ -131,12 +137,12 @@ module.exports = class Doc extends Node
   #
   # Returns nothing.
   parse_description: (section) ->
-    if md = /([A-Z]\w+)\:((.|[\r\n])*)/g.exec(section)
+    if md = /((?:[A-Z]\w+ ?)+)\:((.|[\r\n])*)/g.exec(section)
       return {
         status:      md[1]
         description: _.str.strip(md[2]).replace(/\r?\n/g, ' ')
       }
-    else if md = /~([A-Z]\w+)\~((.|[\r\n])*)/g.exec(section)
+    else if md = /~((?:[A-Z]\w+ ?)+)\~((.|[\r\n])*)/g.exec(section)
       return {
         status:      md[1]
         description: _.str.strip(md[2]).replace(/\r?\n/g, ' ')
@@ -273,9 +279,10 @@ module.exports = class Doc extends Node
         includes: @includeMixins
         extends: @extendMixins
         concerns: @concerns
-        abstract: @abstract
-        private: @private
-        deprecated: @deprecated
+        abstract: @isAbstract()
+        private: @isPrivate()
+        internal: @isInternal()
+        deprecated: @isDeprecated()
         version: @version
         since: @since
         examples: @examples

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -150,7 +150,7 @@ module.exports = class Parser
             comment.push commentLine[2]?.replace /#/g, "\u0091#"
           else
             # append current global status flag if needed
-            if !/^\s*\w+:/.test(commentLine[2])
+            if !/^\s*(?:\w\s?)+:/.test(commentLine[2])
               commentLine[2] = @globalStatus + ": " + commentLine[2]
             inComment = true
             indentComment =  commentLine[1].length - 1

--- a/theme/default/templates/partials/doc.hamlc
+++ b/theme/default/templates/partials/doc.hamlc
@@ -7,7 +7,6 @@
     - if @doc?.deprecated || @doc?.deprecated is ''
       .note.deprecated
         %strong Deprecated.
-        != @doc.deprecated
 
     - if @doc?.abstract || @doc?.abstract is ''
       .note.abstract
@@ -15,7 +14,20 @@
           This
           = @type
           is abstract.
-        != @doc.abstract
+
+    - if @doc?.internal || @doc?.internal is ''
+      .note.internal
+        %strong
+          This
+          = @type
+          is internal.
+
+    - if @doc?.private || @doc?.private is ''
+      .note.private
+        %strong
+          This
+          = @type
+          is private.
 
     - if @doc?.todos
       - for todo in @doc?.todos

--- a/theme/default/templates/partials/method_list.hamlc
+++ b/theme/default/templates/partials/method_list.hamlc
@@ -10,8 +10,6 @@
           != method.signature
         - if method.bound
           (bound)
-        - if method.doc?.private
-          (private)
 
         - if @parent.repo
           - filePath = @parent.classData?.file || "#{@parent.filepath}/#{@parent.filename}"

--- a/theme/default/templates/partials/method_summary.hamlc
+++ b/theme/default/templates/partials/method_summary.hamlc
@@ -12,6 +12,9 @@
       - if method.doc?.private
         %span.private.note.title Private
 
+      - if method.doc?.internal
+        %span.internal.note.title Internal
+
       - if method.doc?.abstract || method.doc?.abstract is ''
         %span.abstract.note.title Abstract
 
@@ -21,6 +24,5 @@
       %span.desc
         - if method.doc?.deprecated || method.doc?.deprecated is ''
           %strong Deprecated.
-          != method.doc?.deprecated
         - else
           != method.doc?.summary


### PR DESCRIPTION
Somewhere along the way modifying you forgot to adjust the exported JSON, et voilà those fancy badges (Internal, Private, Abstract) are missing. I fixed that bug and adjusted the regex at some points to allow multiple types to be used:

``` coffee
# Internal Abstracted Deprecated: Construct an instance representing the git repository.
#
# cwd - The {String} representing the cwd.
#
# Returns: The {GitPromised} instance.
```

I really really like the "Constructor" badge so I re added it, feel free to remove it again.

I can't get your grunt tests to run, jasmine version seems too outdated to start, you might want to take a look at that yourself anyways. :wink:

Oh, and there is a bug in your README, quote

> If you don't have one of these status indicators, Biscotto will assume the global visibility (more on this below).

Looking at the source code you make everything `private` by default.

![hello](https://cloud.githubusercontent.com/assets/5219415/3524361/0bf7a2ec-0767-11e4-876e-95789c4be01c.png)

Oh and I have one question regarding coffeescript/js naming: Am I right when I name my methods like this:

``` coffee
# Internal: I'm internal, call me when you really know what you are doing!
recalculateCallCost: ->
  @callCost = @timeCalled * 0.015

# Private: You can't access me anyways
dirtyThings = ->
  "You are a bad one, aren't you?"
```

Or are `internal` and `private` the opposite of what I am thinking?
