### PR TITLE
Lock underscore to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "walkdir": ">= 0.0.2",
     "optimist": "~0.3.5",
     "marked": ">= 0.1.9",
-    "underscore": ">= 0.1.0",
+    "underscore": "1.6.0",
     "underscore.string": ">= 0.1.0",
     "haml-coffee": ">= 0.6.0",
     "mkdirp": ">= 0.1.0",


### PR DESCRIPTION
Something seems to have changed with `_.clone`, it breaks.
